### PR TITLE
Add Support For New Style Finagle Stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ Just the binary:
       -finagle_server="localhost:9990": finagle stats server:port
       -stats_path="stats.json": finagle stat path
       -statsd_server="localhost:8125": statsd server:port
+      -metrics="true": metrics style finagle stats (non-ostrich)"


### PR DESCRIPTION
Ostrich style stats have been [deprecated](https://twitter.github.io/twitter-server/Migration.html) in favor of a flat-style JSON structure. 

This PR adds support for the updated Finagle stats. The "Ostrich" style stats are what the exporter will expect by default, but the "Metrics" style stats can be enabled by setting the `-metrics` flag to `true`.
